### PR TITLE
Add Site Map Page

### DIFF
--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -1,3 +1,16 @@
+import SiteMapList from "@/components/SiteMapList";
+import Link from "next/link";
+
 export default function SiteMapPage() {
-  return <div>SiteMap</div>
+  return (
+    <>
+      <h1>Site Map</h1>
+      <p>
+        This lists every page on the wiki! If you are feeling overwhelmed, check
+        out the <Link href="/guides/">guides listing page</Link>, or try using the
+        search in the top right corner.
+      </p>
+      <SiteMapList />
+    </>
+  )
 }

--- a/components/SiteMapList.tsx
+++ b/components/SiteMapList.tsx
@@ -9,7 +9,59 @@ type SiteMapTree = {
   children: SiteMapTree[]
 }
 
-const SiteMapList = () => {
+const sortAlphaByTitle = (a: SiteMapTree, b: SiteMapTree) => {
+  if (a.title < b.title) return -1
+  if (a.title > b.title) return 1
+  return 0
+}
+
+const TreeView = ({tree}: any) => {
+  return (
+    <ul className="list-disc mb-0">
+      {tree.href && (
+        <li>
+          {/*<a href={tree.slug}>{tree.title}</a>*/}
+          <Link
+            href={tree.href}
+            key={tree.id}>{tree.title}
+          </Link>
+        </li>
+      )}
+      {tree.children &&
+        tree.children
+          .sort(sortAlphaByTitle)
+          .map((child: SiteMapTree) => <TreeView key={child.id} tree={child} />)}
+    </ul>
+  )
+}
+
+const CardView = ({ tree }: any) => {
+  return (
+    <>
+      {tree.href && (
+        <a
+          href={tree.href}
+          className="w-full h-32 p-4 border text-gray-800 bg-gray-200 shadow-sm transition hover:bg-gray-600 hover:font-bold hover:shadow-md"
+        >
+          {tree.title}
+        </a>
+      )}
+      {tree.children &&
+        tree.href !== "/courses/" &&
+        tree.children.sort(sortAlphaByTitle).map((child: any) => (
+          <a
+            key={child.id}
+            href={child.href}
+            className="w-full h-32 p-4 border text-gray-800 bg-gray-200 shadow-sm transition hover:text-white hover:bg-gray-600 hover:font-bold hover:shadow-md"
+          >
+            {child.title}
+          </a>
+        ))}
+    </>
+  )
+}
+
+const SiteMapList = ({type}: any) => {
   const fs = require('fs')
   const path = require('path')
   let id = 0
@@ -87,38 +139,13 @@ const SiteMapList = () => {
   /* Add Markdown Pages under "data/guides" to tree */
   getPagesUnderRoute(path.join(process.cwd(), 'data'), 'guides', root)
 
-  const sortAlphaByTitle = (a: SiteMapTree, b: SiteMapTree) => {
-    if (a.title < b.title) return -1
-    if (a.title > b.title) return 1
-    return 0
-  }
-
-  const TreeView = ({tree}: any) => {
-    return (
-      <ul className="list-disc mb-0">
-        {tree.href && (
-          <li>
-            {/*<a href={tree.slug}>{tree.title}</a>*/}
-            <Link
-              href={tree.href}
-              key={tree.id}>{tree.title}</Link>
-          </li>
-        )}
-        {tree.children &&
-          tree.children
-            .sort(sortAlphaByTitle)
-            .map((child: SiteMapTree) => <TreeView key={child.id} tree={child} />)}
-      </ul>
+  return type === 'card' ? (
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <CardView tree={root}></CardView>
+      </div>
+    ) : (
+      <TreeView tree={root}></TreeView>
     )
-  }
-
-  return (
-    <div>
-        <div>
-            <TreeView tree={root}></TreeView>
-        </div>
-    </div>
-  )
 }
 
 export default SiteMapList

--- a/components/SiteMapList.tsx
+++ b/components/SiteMapList.tsx
@@ -1,0 +1,124 @@
+import { getMDFrontMatter } from "@/utils/frontmatter-parser"
+import { Dirent } from "fs"
+import Link from "next/link"
+
+type SiteMapTree = {
+  title: string 
+  href: string 
+  id: number
+  children: SiteMapTree[]
+}
+
+const SiteMapList = () => {
+  const fs = require('fs')
+  const path = require('path')
+  let id = 0
+
+  const getPagesUnderRoute = (baseDirectory:string, route : string, currNode: SiteMapTree) => {
+    const pagesDirectory = path.join(baseDirectory, route);
+  
+    try {
+      const files = fs.readdirSync(pagesDirectory, {withFileTypes: true})
+
+      /* If the current directory corresponds to a pages directory, simply return */
+      //if (files.some((file: Dirent) => file.name === 'page.tsx')) return
+  
+      const filteredFiles = files.filter((file : Dirent) => file.name.endsWith('.md') || file.name.endsWith('.mdx') || file.isDirectory());
+
+      /* Grab topic title from index.md file */
+      const indexFile = filteredFiles.find((file: Dirent) => file.name.endsWith('index.md'))
+      if (indexFile) {
+        const indexFileContents = fs.readFileSync(path.join(indexFile.path, indexFile.name), {encoding: 'utf8'})
+        const indexFileMetadata = getMDFrontMatter(indexFileContents)
+        currNode.title = indexFileMetadata.title
+      }
+
+      filteredFiles.forEach((file : Dirent) => {
+        const relativeFilePath = path.join(route, file.name)
+        const stats = fs.statSync(path.join(pagesDirectory, file.name))
+        
+        /* 
+          If the child directory has brackets (meaning it's a subdirectory of a page and not it's own page) 
+          or the sitemap itself, don't include them in the tree
+        */
+        if (file.name.match(/\[.+\]/) || file.name.includes('sitemap')) {
+          return
+        }
+        if (stats.isDirectory()) {
+          let newNode: SiteMapTree = {
+            title: file.name.charAt(0).toUpperCase() + file.name.substring(1).toLowerCase(),
+            href: relativeFilePath,
+            id: id++,
+            children: []
+          }
+
+          currNode.children.push(newNode)
+
+          getPagesUnderRoute(baseDirectory, relativeFilePath, newNode)
+        } else if (!file.name.endsWith('index.md')){
+          const fullFilePath = path.join(baseDirectory, relativeFilePath)
+          const contents = fs.readFileSync(fullFilePath, {encoding: 'utf8'})
+          const guideData = getMDFrontMatter(contents)
+
+          let newNode: SiteMapTree = {
+            title: guideData.title,
+            href: relativeFilePath,
+            id: id++,
+            children: []
+          }
+          currNode.children.push(newNode)
+        }
+      })
+    } catch (error) {
+      console.error(`Error reading directory ${pagesDirectory}:`, error);
+    }
+  }
+
+  let root : SiteMapTree = {
+    title: '',
+    href: '',
+    id: id++,
+    children: []
+  }
+
+  /* Add Pages under "app" directory to tree */
+  getPagesUnderRoute(path.join(process.cwd(), 'app'), '', root)
+
+  /* Add Markdown Pages under "data/guides" to tree */
+  getPagesUnderRoute(path.join(process.cwd(), 'data'), 'guides', root)
+
+  const sortAlphaByTitle = (a: SiteMapTree, b: SiteMapTree) => {
+    if (a.title < b.title) return -1
+    if (a.title > b.title) return 1
+    return 0
+  }
+
+  const TreeView = ({tree}: any) => {
+    return (
+      <ul className="list-disc mb-0">
+        {tree.href && (
+          <li>
+            {/*<a href={tree.slug}>{tree.title}</a>*/}
+            <Link
+              href={tree.href}
+              key={tree.id}>{tree.title}</Link>
+          </li>
+        )}
+        {tree.children &&
+          tree.children
+            .sort(sortAlphaByTitle)
+            .map((child: SiteMapTree) => <TreeView key={child.id} tree={child} />)}
+      </ul>
+    )
+  }
+
+  return (
+    <div>
+        <div>
+            <TreeView tree={root}></TreeView>
+        </div>
+    </div>
+  )
+}
+
+export default SiteMapList

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,12 @@ const nextConfig = {
       test: /\.mdx$/,
       use: "raw-loader",
     })
+
+    config.resolve.fallback = { 
+      fs: false, 
+      path:false 
+    }
+
     return config
   },
   experimental: {


### PR DESCRIPTION
The GraphQL code of the original wiki relied on Gatsby built in API functions which weren't available and my attempts using nextjs GraphQL libraries (Apollo Client) were unsuccessful :(. I ended up writing some code to create the sitemap in JS directly.